### PR TITLE
Ezd/debug find dupes 2 pt2

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,12 @@ import path from 'path';
 
 export const BASE_DIR = path.resolve(__dirname, '..');
 
+const LOG_DIR_NAME = 'logs';
+export const LOG_DIR_PATH = [
+  BASE_DIR,
+  LOG_DIR_NAME,
+].join(path.sep);
+
 const DATA_DIR_NAME = 'data';
 export const DATA_DIR_PATH = [
   BASE_DIR,

--- a/src/lib/cmd/scan-dir/find-duplicate-files2.ts
+++ b/src/lib/cmd/scan-dir/find-duplicate-files2.ts
@@ -54,7 +54,7 @@ maxDupePromises = 1;
 
 const rflMod = 500;
 
-const INTERRUPT_MS = 1e3;
+const ITER_INTERRUPT_MS = 1e3;
 
 // const FMT_DUPES_INTERRUPT_MOD = 666;
 const FMT_DUPES_INTERRUPT_MOD = 333;
@@ -465,9 +465,7 @@ async function formatDupes2(dupesFilePath: string, hashSizeMap: Map<string, numb
         assert(dupeCount !== undefined);
         // if((hsIdx % FMT_DUPES_INTERRUPT_MOD) === 0) {
         // if(resetFhCounter++ >= FMT_DUPES_INTERRUPT_MOD) {
-        if(
-          (resetFhTimer.currentMs() >= 6.666e3)
-        ) {
+        if(resetFhTimer.currentMs() >= 7.5e3) {
           resetFhCounter = 0;
           resetFhMs = resetFhTimer.currentMs();
           process.stdout.write(`${resetFmtFn('✗')}`);
@@ -491,8 +489,9 @@ async function formatDupes2(dupesFilePath: string, hashSizeMap: Map<string, numb
         });
         currFhSeeks++;
         innerLoopCount += seekForHashRes.innerLoopCount;
-        debug2Ws?.write(`ilc: ${innerLoopCount}\n`);
-        debug2Ws?.write(`curr fh seeks: ${currFhSeeks}\n`);
+        // debugWs?.write(`curr fh seeks: ${currFhSeeks}\n`);
+        debugWs?.write(`ilc: ${innerLoopCount}\n`);
+        debugWs?.write(`ilcAvg: ${(Math.round((innerLoopCount / hsIdx) * 100) / 100)}\n`);
 
         foundDupes += dupeCount;
 
@@ -503,7 +502,7 @@ async function formatDupes2(dupesFilePath: string, hashSizeMap: Map<string, numb
           process.stdout.write('.');
         }
 
-        if(iterTimer.currentMs() > INTERRUPT_MS) {
+        if(iterTimer.currentMs() > ITER_INTERRUPT_MS) {
           /*
             force the loop to execute async so that it is interruptable
               by signals like SIGINT, SIGTERM
@@ -588,9 +587,7 @@ async function seekForHash(opts: SeekForHashOpts): Promise<SeekForHashRes> {
   pos = 0;
   skip = false;
 
-  buf.fill(0);
-
-  opts.debug2Ws?.write(`target hash: ${targetHash.substring(0, 7)}\n`);
+  opts.debug2Ws?.write(`${targetHash.substring(0, 7)}\n`);
 
   for(;;) {
     let bufStr: string;

--- a/src/lib/cmd/scan-dir/scan-dir-colors.ts
+++ b/src/lib/cmd/scan-dir/scan-dir-colors.ts
@@ -26,6 +26,8 @@ const coral = CliColors.rgb(219, 136, 105);
 // const peach = CliColors.rgb(255, 193, 112);
 // const peach = CliColors.rgb(255, 202, 133);
 const peach = CliColors.rgb(255, 197, 109);
+// const tomato = CliColors.rgb(255, 86, 53);
+const tomato = CliColors.rgb(255, 101, 71);
 
 const yellow_yellow = CliColors.rgb(255, 255, 0);
 const aqua = CliColors.rgb(96, 226, 182);
@@ -57,6 +59,7 @@ const ezdColors = {
   gray_xlight,
   coral,
   peach,
+  tomato,
   yellow_yellow,
   yellow_light,
   aqua,


### PR DESCRIPTION
fixed the issue with `formatDupes2()` where long-running commands with many possible duplicate files quits without error after 20-45 minutes.